### PR TITLE
Manage admin users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,10 +2,41 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isAdmin() {
+      return request.auth != null && exists(/databases/$(database)/documents/admins/$(request.auth.uid));
+    }
+
+    match /admins/{id}/{document=**} {
+      allow get: if request.auth != null && request.auth.uid == id;
+    }
+
+    match /locations/{id} {
+      allow read: if true;
+
+      match /revisions/{document=**} {
+        allow write: if isAdmin();
+      }
+    }
+
+    match /requests/{id} {
+      allow read: if true;
+
+      match /revisions/{document=**} {
+        allow write: if isAdmin();
+      }
+    }
+
+    match /commitments/{id} {
+      allow read: if true;
+
+      match /revisions/{document=**} {
+        allow write: if isAdmin();
+      }
+    }
+
     match /{document=**} {
-      allow delete: if false;
-    	allow read, create: if true;
-      allow update: if false;
+      allow read: if false;
+      allow write: if false;
     }
   }
 }

--- a/src/components/auth-button/index.js
+++ b/src/components/auth-button/index.js
@@ -4,7 +4,7 @@ import { Button } from 'reactstrap';
 import useFirebaseUser from '@hooks/use-firebase-user';
 
 const AuthButton = ({ onLogin, onLogout, loading }) => {
-  const user = useFirebaseUser();
+  const { user } = useFirebaseUser();
 
   return user ? (
     <Button color="primary" onClick={onLogout} disabled={loading}>

--- a/src/components/commitment-form-modal/index.js
+++ b/src/components/commitment-form-modal/index.js
@@ -23,7 +23,7 @@ import RequestFormModal from '../request-form-modal';
 import useFirebaseUser from '@hooks/use-firebase-user';
 
 const CommitmentFormModal = ({ isShow, toggle, location }) => {
-  const user = useFirebaseUser();
+  const { user } = useFirebaseUser();
   const defaults = {
     location,
     type: '',

--- a/src/components/location-form-modal/index.js
+++ b/src/components/location-form-modal/index.js
@@ -20,7 +20,7 @@ import firebase from 'gatsby-plugin-firebase';
 import useFirebaseUser from '@hooks/use-firebase-user';
 
 const LocationFormModal = ({ isShow, toggle }) => {
-  const user = useFirebaseUser();
+  const { user } = useFirebaseUser();
   const [loading, setLoading] = React.useState(false);
 
   const addLocation = async data => {

--- a/src/components/request-form-modal/index.js
+++ b/src/components/request-form-modal/index.js
@@ -23,7 +23,7 @@ import useFirebaseUser from '@hooks/use-firebase-user';
 import { NEED_TYPE_CHOICES, UNIT_CHOICES } from '@src/constants';
 
 const RequestFormModal = ({ isShow, toggle, location, locationName }) => {
-  const user = useFirebaseUser();
+  const { user } = useFirebaseUser();
   const defaults = {
     location,
     type: '',

--- a/src/hooks/use-firebase-user.js
+++ b/src/hooks/use-firebase-user.js
@@ -3,13 +3,25 @@ import firebase from 'gatsby-plugin-firebase';
 
 const useFirebaseUser = () => {
   const [user, setUser] = useState(null);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     setUser(firebase.auth().currentUser);
-    firebase.auth().onAuthStateChanged(setUser);
+    firebase.auth().onAuthStateChanged(async user => {
+      setUser(user);
+      setIsAdmin(false);
+
+      if (user) {
+        const snapshot = await firebase
+          .firestore()
+          .doc(`admins/${user.uid}`)
+          .get();
+        setIsAdmin(snapshot.exists);
+      }
+    });
   }, []);
 
-  return user;
+  return { user, isAdmin };
 };
 
 export default useFirebaseUser;

--- a/src/page-templates/location.js
+++ b/src/page-templates/location.js
@@ -67,7 +67,7 @@ const watchLocationCommitments = (id, callback) => {
 };
 
 const LocationTemplate = ({ location }) => {
-  const user = useFirebaseUser();
+  const { user } = useFirebaseUser();
 
   const [data, setData] = useState(null);
   const [requests, setRequests] = useState(null);

--- a/src/page-templates/location.js
+++ b/src/page-templates/location.js
@@ -67,7 +67,7 @@ const watchLocationCommitments = (id, callback) => {
 };
 
 const LocationTemplate = ({ location }) => {
-  const { user } = useFirebaseUser();
+  const { user, isAdmin } = useFirebaseUser();
 
   const [data, setData] = useState(null);
   const [requests, setRequests] = useState(null);
@@ -149,14 +149,16 @@ const LocationTemplate = ({ location }) => {
               <h3>Requests</h3>
             </Col>
             <Col className="d-flex justify-content-end">
-              <Button
-                color="primary"
-                size="sm"
-                className={style.addButton}
-                onClick={toggleRequestModal}
-              >
-                Add a request
-              </Button>
+              {isAdmin && (
+                <Button
+                  color="primary"
+                  size="sm"
+                  className={style.addButton}
+                  onClick={toggleRequestModal}
+                >
+                  Add a request
+                </Button>
+              )}
             </Col>
           </Row>
           {requests && <RequestsTable data={requests} />}
@@ -166,14 +168,16 @@ const LocationTemplate = ({ location }) => {
               <h3>Donations</h3>
             </Col>
             <Col className="d-flex justify-content-end">
-              <Button
-                color="primary"
-                size="sm"
-                className={style.addButton}
-                onClick={toggleCommitmentModal}
-              >
-                Add a donation
-              </Button>
+              {isAdmin && (
+                <Button
+                  color="primary"
+                  size="sm"
+                  className={style.addButton}
+                  onClick={toggleCommitmentModal}
+                >
+                  Add a donation
+                </Button>
+              )}
             </Col>
           </Row>
           {commitments && <CommitmentsTable data={commitments} />}


### PR DESCRIPTION
- Update security rules to only allow creation from admin users
- Add an `admins` collection. Each document key in here should be the UID of a Firebase Auth user
- Hide **Add request** and **Add donation** buttons in the UI if the user is not an admin